### PR TITLE
Workaround for JSON deserialization limit on PowerShell 4.0 and earlier

### DIFF
--- a/src/MsrcSecurityUpdates/Private/ParseJsonString.ps1
+++ b/src/MsrcSecurityUpdates/Private/ParseJsonString.ps1
@@ -1,0 +1,52 @@
+# ParseJsonString converts from string to PowerShell objects
+# (workaround to overcome ConvertFrom-Json limitation on PowerShell 4.0 and earlier)
+
+# Based on code by Florian Feldhaus at 'ConvertFrom-Json max length'
+# https://stackoverflow.com/questions/16854057/convertfrom-json-max-length
+# With the following changes:
+# - ParseJsonString calls ParseItem, not ParseJsonObject (suggested by Dmitry Lobanov)
+# - if-else test in ParseJsonObject is replaced by '$parsedItem = ParseItem $item'
+# Note: this code is much slower than ConvertFrom-Json
+
+Add-Type -Assembly System.Web.Extensions
+
+# .NET JSON Serializer 
+$javaScriptSerializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
+$javaScriptSerializer.MaxJsonLength = [System.Int32]::MaxValue
+$javaScriptSerializer.RecursionLimit = 99
+
+# Functions necessary to parse JSON output from .NET serializer to PowerShell Objects
+function ParseItem($jsonItem) {
+        if($jsonItem.PSObject.TypeNames -match "Array") {
+                return ParseJsonArray($jsonItem)
+        }
+        elseif($jsonItem.PSObject.TypeNames -match "Dictionary") {
+                return ParseJsonObject([HashTable]$jsonItem)
+        }
+        else {
+                return $jsonItem
+        }
+}
+
+function ParseJsonObject($jsonObj) {
+        $result = New-Object -TypeName PSCustomObject
+        foreach ($key in $jsonObj.Keys) {
+                $item = $jsonObj[$key]
+                $parsedItem = ParseItem $item
+                $result | Add-Member -MemberType NoteProperty -Name $key -Value $parsedItem
+        }
+        return $result
+}
+
+function ParseJsonArray($jsonArray) {
+        $result = @()
+        $jsonArray | ForEach-Object {
+                $result += , (ParseItem $_)
+        }
+        return $result
+}
+
+function ParseJsonString($json) {
+        $config = $javaScriptSerializer.DeserializeObject($json)
+        return ParseItem($config)
+}

--- a/src/MsrcSecurityUpdates/Public/Get-MsrcCvrfDocument.ps1
+++ b/src/MsrcSecurityUpdates/Public/Get-MsrcCvrfDocument.ps1
@@ -110,11 +110,18 @@ Process {
     
             Write-Verbose -Message "Calling $($RestMethod.uri)"
 
-            Invoke-RestMethod @RestMethod
+            $response = Invoke-RestMethod @RestMethod
      
         } catch {
             Write-Error "HTTP Get failed with status code $($_.Exception.Response.StatusCode): $($_.Exception.Response.StatusDescription)"       
         }
+    
+        # Invoke-RestMethod will return an string on PowerShell 4.0 and earlier
+        # if the JSON-formatted response is larger than about two million characters
+        if (-not $AsXml -and $response -is [string]) {
+            $response = ParseJsonString($response)
+        }
+        $response
     }
 }
 End {}


### PR DESCRIPTION
Quick fix for issue #20

Invoke-RestMethod on PowerShell 4.0 and earlier can't deserialize JSON responses larger than 2097152 characters. MSRC API responses for March 2017 and June 2017 exceed this limit, so Invoke-RestMethod (and therefore Get-MsrcCrvfDocument) returns the original string data instead of a PowerShell object. Get-MsrcSecurityBulletinHtml and Get-MsrcVulnerabilityReportHtml can't consume this string.

Not needed on PowerShell 5.0 and later.

Submission containing materials of a third party: Florian Feldhaus at https://stackoverflow.com/questions/16854057/convertfrom-json-max-length (forum contribution, no license attached)