### PR TITLE
Fix for duplicate CVSSScoreSets for the same productId

### DIFF
--- a/src/MsrcSecurityUpdates/Private/Get-CVRFID.ps1
+++ b/src/MsrcSecurityUpdates/Private/Get-CVRFID.ps1
@@ -39,11 +39,13 @@ Process {
         if ($ID) {
 
             (Invoke-RestMethod @RestMethod).Value | 
-            Where-Object { $_.ID -eq $ID }
+            Where-Object { $_.ID -eq $ID } | 
+            Where-Object { $_ -ne '2017-May-B' }
     
         } else {
         
-            ((Invoke-RestMethod @RestMethod).Value).ID
+            ((Invoke-RestMethod @RestMethod).Value).ID | 
+            Where-Object { $_ -ne '2017-May-B' }
         }
 
     } catch {

--- a/src/MsrcSecurityUpdates/Private/Get-KBDownloadUrl.ps1
+++ b/src/MsrcSecurityUpdates/Private/Get-KBDownloadUrl.ps1
@@ -10,32 +10,34 @@ Function Get-KBDownloadUrl {
         The KB Article object that contains the id, url, and subtype.
 
     .EXAMPLE
-        [PSCustomObject]{ID="kb123456"; URL="microsoft.com"; SubType="Required"} | Get-KBDownloadUrl
+        [PSCustomObject]@{ID="kb123456"; URL="microsoft.com"; SubType="Required"} | Get-KBDownloadUrl
 #>
-    [CmdletBinding()]
-    Param (
-        [Parameter(Mandatory,ValueFromPipeline)]
-        [PSCustomObject]$KBArticleObject
-    )
-    Begin {
-        $HTML_TO_RETURN = @()
-    }
-    Process {
-        if (-not($KBArticleObject)){
-            'None'
-        } else {
+[CmdletBinding()]
+Param (
+    [Parameter(Mandatory,ValueFromPipeline)]
+    [PSCustomObject]$KBArticleObject
+)
+Begin {
+    $HTML_TO_RETURN = @()
+}
+Process {
+    if (-not($KBArticleObject)){
+        'None'
+    } else {
         
-            foreach($kb in $KBArticleObject){
-                #In older months, there won't be a subtype. Handle this so there are not empty ()'s
-                if($KBArticleObject.SubType -ne $null){
-                    $HTML_TO_RETURN += $('<a href="{0}" >{1} ({2})' -f $kb.URL, $kb.ID, $kb.SubType)
-                } else {
-                    $HTML_TO_RETURN += $('<a href="{0}" >{1}' -f $kb.URL, $kb.ID)
-                }
+        $KBArticleObject | 
+        ForEach-Object {
+            $kb = $_
+            #In older months, there won't be a subtype. Handle this so there are not empty ()'s
+            if($kb.SubType){
+                $HTML_TO_RETURN += $('<a href="{0}" >{1} ({2})' -f $kb.URL, $kb.ID, $kb.SubType)
+            } else {
+                $HTML_TO_RETURN += $('<a href="{0}" >{1}' -f $kb.URL, $kb.ID)
             }
         }
     }
-    End {
-        return $HTML_TO_RETURN -join '<br />'
-    }
+}
+End {
+    $HTML_TO_RETURN -join '<br />'
+}
 }

--- a/src/MsrcSecurityUpdates/Public/Get-MsrcCvrfAffectedSoftware.ps1
+++ b/src/MsrcSecurityUpdates/Public/Get-MsrcCvrfAffectedSoftware.ps1
@@ -87,10 +87,10 @@ Process {
                         "$($_)"
                     }
                 ) ;
-                CvssScoreSet = $( [PSCustomObject] @{ 
-                        base=    ($v.CVSSScoreSets | Where-Object { $_.ProductID -contains $id } ).BaseScore;
-                        temporal=($v.CVSSScoreSets | Where-Object { $_.ProductID -contains $id } ).TemporalScore;;
-                        vector=  ($v.CVSSScoreSets | Where-Object { $_.ProductID -contains $id } ).Vector;
+                CvssScoreSet = $( [PSCustomObject]@{ 
+                        base=    ($v.CVSSScoreSets | Where-Object { $_.ProductID -contains $id } | Select-Object -First 1).BaseScore;
+                        temporal=($v.CVSSScoreSets | Where-Object { $_.ProductID -contains $id } | Select-Object -First 1).TemporalScore;;
+                        vector=  ($v.CVSSScoreSets | Where-Object { $_.ProductID -contains $id } | Select-Object -First 1).Vector;
                     }
                 ) ;
             }


### PR DESCRIPTION
When you create the html report for this month using Get-MsrcVulnerabilityReportHtml, the CVSSScoreSets are displayed as:
Base: System.Object[]
Temporal: System.Object[]
Vector: System.Object[]