### PR TITLE
Fix supersede typo in MSRC swagger API

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -470,7 +470,7 @@
                     "URL": {
                       "type": "string"
                     },
-                    "Supercedence": {
+                    "Supersedence": {
                       "type": "string"
                     },
                     "ProductID": {
@@ -1063,7 +1063,7 @@
                         },
                         "type": "string"
                       },
-                      "Supercedence": {
+                      "Supersedence": {
                         "xml": {
                           "prefix": "vuln"
                         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -325,7 +325,7 @@ definitions:
                         type: string
                   URL:
                     type: string
-                  Supercedence:
+                  Supersedence:
                     type: string
                   ProductID:
                     type: array
@@ -725,7 +725,7 @@ definitions:
                       xml:
                         prefix: vuln
                       type: string
-                    Supercedence:
+                    Supersedence:
                       xml:
                         prefix: vuln
                       type: string

--- a/src/MsrcSecurityUpdates/Public/Get-MsrcCvrfAffectedSoftware.ps1
+++ b/src/MsrcSecurityUpdates/Public/Get-MsrcCvrfAffectedSoftware.ps1
@@ -79,11 +79,11 @@ Process {
                         "$($_)"
                     }
                 ) ;
-                Supercedence = $(
+                Supersedence = $(
                     (
                         $v.Remediations | 
                         Where-Object { $_.ProductID -contains $id }
-                    ).Supercedence | ForEach-Object {
+                    ).Supersedence | ForEach-Object {
                         "$($_)"
                     }
                 ) ;

--- a/src/MsrcSecurityUpdates/Public/Get-MsrcVulnerabilityReportHtml.ps1
+++ b/src/MsrcSecurityUpdates/Public/Get-MsrcVulnerabilityReportHtml.ps1
@@ -396,10 +396,10 @@ Process {
                         }
                     ),
                     $( 
-                        if (-not($_.Supercedence)) {
+                        if (-not($_.Supersedence)) {
                             'None'
                         } else { 
-                            $($_.Supercedence | Select-Object -Unique) -join '<br />'
+                            $($_.Supersedence | Select-Object -Unique) -join '<br />'
                         }
                     ),
                     $(


### PR DESCRIPTION
I've gone ahead and edited all the files in my quick grep of the codebase relating to the [issue I opened](https://github.com/Microsoft/MSRC-Microsoft-Security-Updates-API/issues/32) - I realize there's probably more that needs to happen on the back-end for this.