### PR TITLE
Add hint to fill in the name field in the account used to request the API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Welcome
-Microsoft provides an API for getting security update details using [Common Vulnerability Reporting Format](http://www.icasi.org/cvrf/). View our [blog post](https://blogs.technet.microsoft.com/msrc/2016/11/08/furthering-our-commitment-to-security-updates/) for more info. 
+Microsoft provides an API for getting security update details using [Common Vulnerability Reporting Format](http://www.icasi.org/cvrf/). View our [blog post](https://blogs.technet.microsoft.com/msrc/2016/11/08/furthering-our-commitment-to-security-updates/) for more info.
 
 The [Security Updates Guide](https://portal.msrc.microsoft.com/en-us/security-guidance) is a great place to find security updates in a browser, and the Security Updates API is intended for doing automation around Microsoft security updates.
 
@@ -29,7 +29,7 @@ __NOTE: Currently generating api keys requires an @outlook.com, @live.com, or @m
 # Change Log
 **_For up to date major changes, please read the psd1 included in the src folder. This can also be seen on [the Microsoft Powershell Gallery](https://www.powershellgallery.com/packages/MsrcSecurityUpdates)._**
 
-**May 2017** - Added RestartRequired and SubType to the remediations object in the API response. 
+**May 2017** - Added RestartRequired and SubType to the remediations object in the API response.
 
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once the module is loaded, check out our [PowerShell samples](https://github.com
 # API Keys
 The Security Updates API requires an API key.  To obtain an API key please visit the [Security Updates Guide](https://portal.msrc.microsoft.com/en-us/security-guidance).  For help using the Security Updates Guide please visit the [Security Updates Guide Community Forum](https://social.technet.microsoft.com/Forums/security/en-us/home?forum=securityupdateguide).
 
-__NOTE: Currently generating api keys requires an @outlook.com, @live.com, or @microsoft.com email address. If you do not have one of these email addresses, you can create a personal outlook account to access this service while we investigate this issue.__
+__NOTE: Currently generating api keys requires an @outlook.com, @live.com, or @microsoft.com email address. If you do not have one of these email addresses, you can create a personal outlook account to access this service while we investigate this issue. Also, you must set your name on the [account.microsoft.com](https://account.microsoft.com/) website, otherwise the generation of the API key might fail silently.__
 
 # Change Log
 **_For up to date major changes, please read the psd1 included in the src folder. This can also be seen on [the Microsoft Powershell Gallery](https://www.powershellgallery.com/packages/MsrcSecurityUpdates)._**


### PR DESCRIPTION
When requesting an API key one needs to set the name field in the Microsoft account via account.microsoft.com, otherwise the request website (Security Updates Guide) will run in circles (login, request, login, request, login, ...), as discussed in issue #15.