### PR TITLE
Update to v3 endpoint

### DIFF
--- a/src/MsrcSecurityUpdates/Private/Set-GlobalVariables.ps1
+++ b/src/MsrcSecurityUpdates/Private/Set-GlobalVariables.ps1
@@ -1,6 +1,6 @@
 ﻿# we also set other shared variables
-$global:msrcApiUrl     = 'https://api.msrc.microsoft.com/cvrf/v2.0'
+$global:msrcApiUrl     = 'https://api.msrc.microsoft.com/cvrf/v3.0'
 Write-Verbose -Message "Successfully defined a msrcApiUrl global variable that points to $($global:msrcApiUrl)"
 
-$global:msrcApiVersion = 'api-version=2016-08-01'
+$global:msrcApiVersion = 'api-version=2023-11-01'
 Write-Verbose -Message "Successfully defined a msrcApiVersion global variable that points to $($global:msrcApiVersion)"


### PR DESCRIPTION
This updates the API endpoints to the default v3.0. This is fully compatible with the v2.0 endpoints including schema.